### PR TITLE
refactor: remove silex.sile dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This package for the [SILE](https://github.com/sile-typesetter/sile) typesetting
 system provides ways to typeset superscripted or subscripted text properly,
-using real characters (i.e. based on OpênType font properties) or fake (scaled
+using real (i.e. based on OpênType font properties) or fake (scaled
 and raised) characters, with several tuning options.
 
 As it names imply, it is not a general-purpose super/subscript package, but it
@@ -24,7 +24,7 @@ output for superscripted or subscripted text, with appropriate fallbacks.
 
 ## Installation
 
-This package require SILE v0.14 or upper.
+This package require SILE v0.14.13 or upper.
 
 Installation relies on the **luarocks** package manager.
 

--- a/packages/textsubsuper/init.lua
+++ b/packages/textsubsuper/init.lua
@@ -169,17 +169,11 @@ function package:registerCommands ()
   end
 
   local function rescaleContent(content)
-    local transformed
-    if SILE.outputter._name ~= "libtexpdf" then
-      -- Not supported
-      transformed = content
-    else
-      transformed = self.class.packages.inputfilter:transformContent(content, rescaleFilter, {
-        xScale = 1,
-        yScaleNumber = SILE.settings:get("textsubsuper.vscale.number"),
-        yScaleOther = SILE.settings:get("textsubsuper.vscale.other"),
-      })
-    end
+    local transformed = self.class.packages.inputfilter:transformContent(content, rescaleFilter, {
+      xScale = 1,
+      yScaleNumber = SILE.settings:get("textsubsuper.vscale.number"),
+      yScaleOther = SILE.settings:get("textsubsuper.vscale.other"),
+    })
     SILE.process(transformed)
    end
 

--- a/textsubsuper.sile-1.1.1-1.rockspec
+++ b/textsubsuper.sile-1.1.1-1.rockspec
@@ -1,7 +1,9 @@
+rockspec_format = "3.0"
 package = "textsubsuper.sile"
-version = "dev-1"
+version = "1.1.1-1"
 source = {
   url = "git+https://github.com/Omikhleia/textsubsuper.sile.git",
+  tag = "v1.1.1",
 }
 description = {
   summary = "Real or fake superscripts and subscripts for the SILE typesetting system.",


### PR DESCRIPTION
Closes #6 

The only reasons why it was here is for the scalebox command (introduced in SILE 0.14.9) and its re-implementation in silex.sile for full-bleed printing. When used outside the resilient collection this is not needed, and when used with it, the silex layers are already loaded. So this change should not impact users.

Also, we cannot support forever older versions of SILE, so from this point the minimal supported version is 0.14.13.